### PR TITLE
Bugfixes 11 16

### DIFF
--- a/src/nspyre/gui/data_explorer.py
+++ b/src/nspyre/gui/data_explorer.py
@@ -11,6 +11,7 @@
 
 # std
 import os
+import logging
 
 # 3rd party
 from PyQt5 import QtWidgets, QtCore

--- a/src/nspyre/gui/launcher.py
+++ b/src/nspyre/gui/launcher.py
@@ -13,6 +13,7 @@ Date: 10/30/2019
 # std
 import time
 import traceback
+import logging
 
 # 3rd party
 from PyQt5 import QtWidgets, QtCore

--- a/src/nspyre/gui/main_window.py
+++ b/src/nspyre/gui/main_window.py
@@ -114,16 +114,16 @@ class NSpyreMainWindow(QMainWindow):
         process = QProcess()
         if window_name == 'inserv_manager':
             logger.info('starting Instrument Manager...')
-            process.start('python3', [str(HERE.joinpath('instrument_manager.py'))])
+            process.start('python', [str(HERE.joinpath('instrument_manager.py'))])
         elif window_name == 'view_manager':
             logger.info('starting View Manager...')
-            process.start('python3', [str(HERE.joinpath('view_manager.py')), 'react_to_drop=False'])
+            process.start('python', [str(HERE.joinpath('view_manager.py')), 'react_to_drop=False'])
         elif window_name == 'spyrelet_startup':
             logger.info('starting Syrelet GUI window...')
-            process.start('python3', [str(HERE.joinpath('launcher.py'))])
+            process.start('python', [str(HERE.joinpath('launcher.py'))])
         elif window_name == 'data_explorer':
             logger.info('starting Data Explorer...')
-            process.start('python3', [str(HERE.joinpath('data_explorer.py'))])
+            process.start('python', [str(HERE.joinpath('data_explorer.py'))])
         else:
             raise ValueError('Incorrect input for window_name: {}'.format(window_name))
         self._windows.append(process)

--- a/src/nspyre/gui/view_manager.py
+++ b/src/nspyre/gui/view_manager.py
@@ -14,6 +14,7 @@ import time
 import inspect
 import traceback
 import textwrap
+import logging
 
 # 3rd party
 from PyQt5 import QtWidgets, QtCore, QtGui

--- a/src/nspyre/gui/widgets/views.py
+++ b/src/nspyre/gui/widgets/views.py
@@ -1,7 +1,7 @@
 from nspyre.mongodb.mongo_listener import Synched_Mongo_Collection
 from nspyre.gui.widgets.plotting import LinePlotWidget
 from nspyre.spyrelet.spyrelet import load_spyrelet_class
-from nspyre.config.config_files import load_config
+from nspyre.config.config_files import load_config, load_meta_config
 
 class View():
     def __init__(self, f, plot_type):
@@ -68,7 +68,8 @@ def PlotFormatUpdate(class_type_handled, view_list):
 class Spyrelet_Views():
     def __init__(self, spyrelet_class):
         if type(spyrelet_class) is str:
-            cfg = load_config()
+            cfg_path = load_meta_config()
+            cfg = load_config(cfg_path)
             spyrelet_class = load_spyrelet_class(spyrelet_class, cfg)
 
         self.views = {x:getattr(spyrelet_class, x) for x in dir(spyrelet_class) if type(getattr(spyrelet_class, x)) is View}


### PR DESCRIPTION
v0.4 bug fixes:
1. Nspyre Main Window does not load additional nspyre windows for sub applications on **Windows systems**:
    This is caused from additional QProcesses being ran with python3 instead of python, which is not in the conda env bin for Windows machines for some reason.
2. The spin box and additional _Instrument Manager_ widgets has trouble inferring correct base units from the lantz drivers/pint. This is fixed by implementing the `infer_base_units()` method in inspire
3. views.py line 71 has a missing argument for config file handling