### PR TITLE
Added get_params_value_funs as kwarg for ExperimentWidget

### DIFF
--- a/src/nspyre/gui/widgets/experiment.py
+++ b/src/nspyre/gui/widgets/experiment.py
@@ -5,6 +5,7 @@ from importlib import reload
 from multiprocessing import Queue
 from types import ModuleType
 from typing import Optional
+from typing import Dict
 
 from pyqtgraph.Qt import QtWidgets
 
@@ -33,6 +34,7 @@ class ExperimentWidget(QtWidgets.QWidget):
         title: Optional[str] = None,
         kill: bool = False,
         layout: QtWidgets.QLayout = None,
+        get_param_value_funs: Optional[Dict] = None
     ):
         """
         Args:
@@ -86,7 +88,7 @@ class ExperimentWidget(QtWidgets.QWidget):
         else:
             self.fun_kwargs = {}
 
-        self.params_widget = ParamsWidget(params_config)
+        self.params_widget = ParamsWidget(params_config, get_param_value_funs=get_param_value_funs)
 
         # run button
         run_button = QtWidgets.QPushButton('Run')


### PR DESCRIPTION
The current ExperimentWidget class doesn't allow us to create functions that return values for widgets. As a result, the only widgets that can be used are the ones already defined in ParamsWidget. My change enables users to add functions that return values of widgets to the ExperimentWidget class, which allows users to add their own widgets. 